### PR TITLE
Support amd64, arm64 arch for Docker container

### DIFF
--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -1,36 +1,83 @@
-name: build-docker-container
+name: C/C++ CI
 
 on:
   push:
-    tags: ["v*"] # Push events to matching v*, i.e. v1.0, v20.15.10
+    tags: ["v*"]
+
+env:
+  IMAGE: ghcr.io/montimage-projects/hn-mmt-operator
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            tag_suffix: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            tag_suffix: arm64
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Initialize variables
-      env:
-        GITHUB_REF: ${{ github.ref }}
-      run: |
-        cat <<EOF >> $GITHUB_ENV
-        PACKAGE_VERSION=$(echo $GITHUB_REF | tr -d 'refs/tags/' )
-        EOF
-        
-    - name: Log in to the Container registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        push: true
-        tags: |
-          ghcr.io/montimage/mmt-operator:${{ env.PACKAGE_VERSION }}
-          ghcr.io/montimage/mmt-operator:latest
+      - uses: actions/checkout@v4
+
+      - name: Initialize variables
+        run: |
+          echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: ${{ matrix.platform }}
+          sbom: false
+          tags: |
+            ${{ env.IMAGE }}:${{ env.PACKAGE_VERSION }}-${{ matrix.tag_suffix }}
+
+  # create a single tag (e.g. ghcr.io/montimage/mmt-probe:latest) to automatically 
+  #  point to different images depending on the client's architecture
+  manifest:
+    needs: build
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Initialize variables
+        run: |
+          echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE }}:${{ env.PACKAGE_VERSION }} \
+            -t ${{ env.IMAGE }}:latest \
+            ${{ env.IMAGE }}:${{ env.PACKAGE_VERSION }}-amd64 \
+            ${{ env.IMAGE }}:${{ env.PACKAGE_VERSION }}-arm64


### PR DESCRIPTION
Previously, our Docker containers of MMT-Operator can run only on amd64 arch.
This PR improves GitHub Action script to build  2 different Docker containers of MMT-Operator to support CPU architectures, amd64 and arm64 (Raspberry Pi).